### PR TITLE
Feat/display backup size

### DIFF
--- a/internal/database/migrations/20240811205655_add_file_size_to_executions_table.sql
+++ b/internal/database/migrations/20240811205655_add_file_size_to_executions_table.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE executions ADD COLUMN file_size BIGINT NULL DEFAULT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE executions DROP COLUMN file_size;
+-- +goose StatementEnd

--- a/internal/integration/storage/local.go
+++ b/internal/integration/storage/local.go
@@ -16,7 +16,7 @@ const (
 // LocalUpload Creates a new file using the provided path and reader relative
 // to the local backups directory.
 //
-// Returns the size of the file created.
+// Returns the size of the file created, in bytes.
 func (Client) LocalUpload(relativeFilePath string, fileReader io.Reader) (int64, error) {
 	fullPath := strutil.CreatePath(true, localBackupsDir, relativeFilePath)
 	dir := filepath.Dir(fullPath)

--- a/internal/integration/storage/local.go
+++ b/internal/integration/storage/local.go
@@ -15,27 +15,34 @@ const (
 
 // LocalUpload Creates a new file using the provided path and reader relative
 // to the local backups directory.
-func (Client) LocalUpload(relativeFilePath string, fileReader io.Reader) error {
+//
+// Returns the size of the file created.
+func (Client) LocalUpload(relativeFilePath string, fileReader io.Reader) (int64, error) {
 	fullPath := strutil.CreatePath(true, localBackupsDir, relativeFilePath)
 	dir := filepath.Dir(fullPath)
 
 	err := os.MkdirAll(filepath.Dir(fullPath), os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+		return 0, fmt.Errorf("failed to create directory %s: %w", dir, err)
 	}
 
 	file, err := os.Create(fullPath)
 	if err != nil {
-		return fmt.Errorf("failed to create file %s: %w", fullPath, err)
+		return 0, fmt.Errorf("failed to create file %s: %w", fullPath, err)
 	}
 	defer file.Close()
 
 	_, err = io.Copy(file, fileReader)
 	if err != nil {
-		return fmt.Errorf("failed to write file %s: %w", fullPath, err)
+		return 0, fmt.Errorf("failed to write file %s: %w", fullPath, err)
 	}
 
-	return nil
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get file info %s: %w", fullPath, err)
+	}
+
+	return fileInfo.Size(), nil
 }
 
 // LocalDelete Deletes a file using the provided path relative to the local

--- a/internal/integration/storage/s3.go
+++ b/internal/integration/storage/s3.go
@@ -51,9 +51,9 @@ func (Client) S3Ping(
 	return nil
 }
 
-// S3Upload uploads a file to S3 from a reader
+// S3Upload uploads a file to S3 from a reader.
 //
-// Returns the file size
+// Returns the file size, in bytes.
 func (Client) S3Upload(
 	accessKey, secretKey, region, endpoint, bucketName, key string,
 	fileReader io.Reader,

--- a/internal/service/executions/update_execution.sql
+++ b/internal/service/executions/update_execution.sql
@@ -5,6 +5,7 @@ SET
   message = COALESCE(sqlc.narg('message'), message),
   path = COALESCE(sqlc.narg('path'), path),
   finished_at = COALESCE(sqlc.narg('finished_at'), finished_at),
-  deleted_at = COALESCE(sqlc.narg('deleted_at'), deleted_at)
+  deleted_at = COALESCE(sqlc.narg('deleted_at'), deleted_at),
+  file_size = COALESCE(sqlc.narg('file_size'), file_size)
 WHERE id = @id
 RETURNING *;

--- a/internal/util/strutil/format_file_size.go
+++ b/internal/util/strutil/format_file_size.go
@@ -1,0 +1,22 @@
+package strutil
+
+import "fmt"
+
+// FormatFileSize pretty prints a file size (in bytes) to a human-readable format
+//
+// e.g. 1024 -> 1 KB
+func FormatFileSize(size int64) string {
+	if size < 1024 {
+		return fmt.Sprintf("%d B", size)
+	}
+
+	if size < 1024*1024 {
+		return fmt.Sprintf("%.2f KB", float64(size)/1024)
+	}
+
+	if size < 1024*1024*1024 {
+		return fmt.Sprintf("%.2f MB", float64(size)/(1024*1024))
+	}
+
+	return fmt.Sprintf("%.2f GB", float64(size)/(1024*1024*1024))
+}

--- a/internal/util/strutil/format_file_size_test.go
+++ b/internal/util/strutil/format_file_size_test.go
@@ -1,0 +1,29 @@
+package strutil
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFormatFileSize(t *testing.T) {
+	tests := []struct {
+		size     int64
+		expected string
+	}{
+		{size: 0, expected: "0 B"},
+		{size: 1, expected: "1 B"},
+		{size: 1023, expected: "1023 B"},
+		{size: 1024, expected: "1.00 KB"},
+		{size: 1024*1024 - 10, expected: "1023.99 KB"},
+		{size: 1024 * 1024, expected: "1.00 MB"},
+		{size: 1024*1024*1024 - 10_000, expected: "1023.99 MB"},
+		{size: 1024 * 1024 * 1024, expected: "1.00 GB"},
+		{size: 1024*1024*1024*1024 - 10_000_000, expected: "1023.99 GB"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.expected, func(t *testing.T) {
+			assert.Equal(t, test.expected, FormatFileSize(test.size))
+		})
+	}
+}

--- a/internal/view/web/component/pretty_file_size.go
+++ b/internal/view/web/component/pretty_file_size.go
@@ -1,0 +1,24 @@
+package component
+
+import (
+	"database/sql"
+	"github.com/eduardolat/pgbackweb/internal/util/strutil"
+
+	"github.com/maragudk/gomponents"
+	"github.com/maragudk/gomponents/html"
+)
+
+// PrettyFileSize pretty prints a file size (in bytes) to a human-readable format.
+// If the size is not valid, it returns an empty string.
+//
+// e.g. 1024 -> 1 KB
+func PrettyFileSize(
+	size sql.NullInt64,
+) gomponents.Node {
+	return gomponents.If(
+		size.Valid,
+		html.Span(
+			SpanText(strutil.FormatFileSize(size.Int64)),
+		),
+	)
+}

--- a/internal/view/web/dashboard/executions/index.go
+++ b/internal/view/web/dashboard/executions/index.go
@@ -53,6 +53,7 @@ func indexPage(queryData execsQueryData) gomponents.Node {
 								html.Th(component.SpanText("Started at")),
 								html.Th(component.SpanText("Finished at")),
 								html.Th(component.SpanText("Duration")),
+								html.Th(component.SpanText("Compressed Size")),
 							),
 						),
 						html.TBody(

--- a/internal/view/web/dashboard/executions/list_executions.go
+++ b/internal/view/web/dashboard/executions/list_executions.go
@@ -102,6 +102,12 @@ func listExecutions(
 					),
 				),
 			),
+			html.Td(
+				gomponents.If(
+					execution.FileSize.Valid,
+					component.PrettyFileSize(execution.FileSize),
+				),
+			),
 		))
 	}
 

--- a/internal/view/web/dashboard/executions/show_execution.go
+++ b/internal/view/web/dashboard/executions/show_execution.go
@@ -108,6 +108,13 @@ func showExecutionButton(
 							)),
 						),
 					),
+					gomponents.If(
+						execution.FileSize.Valid,
+						html.Tr(
+							html.Th(component.SpanText("Compressed Size")),
+							html.Td(component.PrettyFileSize(execution.FileSize)),
+						),
+					),
 				),
 				gomponents.If(
 					execution.Status == "success",


### PR DESCRIPTION
Hi there!

Thank you very much for making this piece of software. A GUI database backup project has been on my todo list for a long time, but I'll use yours since it's pretty good!

When using pgbackweb, I wished the size of the backups would be displayed, so I made it. Hope you think it fits the project!

Since I don't think we can't get the size of an `io.Reader` without consuming the stream, I had to pull the file size from the destinations. I just returned a simple `int64`, but I wonder if a struct with a single field would not be better for code sustainability.

![image](https://github.com/user-attachments/assets/00b455df-f2f5-4e56-ad2f-614b25786431)
![image](https://github.com/user-attachments/assets/69deac73-add4-4a51-a98d-15bb81260a7f)

Backups prior to this PR simply won't have a display size