### PR TITLE
Feat/pre-selected timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ services:
     environment:
       PBW_ENCRYPTION_KEY: "my_secret_key"
       PBW_POSTGRES_CONN_STRING: "postgresql://postgres:password@postgres:5432/pgbackweb?sslmode=disable"
+      TZ: "America/Guatemala" # Set your timezone, optional
     depends_on:
       postgres:
         condition: service_healthy
@@ -90,6 +91,9 @@ You only need to configure the following environment variables:
 - `PBW_ENCRYPTION_KEY`: Your encryption key. Generate a strong one and store it in a safe place, as PG Back Web uses it to encrypt sensitive data.
 
 - `PBW_POSTGRES_CONN_STRING`: The connection string for the PostgreSQL database that will store PG Back Web data.
+
+- `TZ`: Your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List), optional. Default is `UTC`.
+For accurate logging and default timezone in the web interface. Can also be a mount point to the host's `/etc/localtime` instead.
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You only need to configure the following environment variables:
 - `PBW_POSTGRES_CONN_STRING`: The connection string for the PostgreSQL database that will store PG Back Web data.
 
 - `TZ`: Your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List), optional. Default is `UTC`.
-For accurate logging and default timezone in the web interface. Can also be a mount point to the host's `/etc/localtime` instead.
+  Impacts logging, backup filenames and default timezone in the web interface. Can also be a mount point to the host's `/etc/localtime` instead.
 
 ## Screenshots
 

--- a/internal/view/web/dashboard/backups/create_backup.go
+++ b/internal/view/web/dashboard/backups/create_backup.go
@@ -2,6 +2,7 @@ package backups
 
 import (
 	"net/http"
+	"time"
 
 	lucide "github.com/eduardolat/gomponents-lucide"
 	"github.com/eduardolat/pgbackweb/internal/database/dbgen"
@@ -101,6 +102,8 @@ func createBackupForm(
 		})
 	}
 
+	serverTZ := time.Now().Location().String()
+
 	return html.Form(
 		htmx.HxPost("/dashboard/backups"),
 		htmx.HxDisabledELT("find button"),
@@ -184,7 +187,12 @@ func createBackupForm(
 				component.GMap(
 					staticdata.Timezones,
 					func(tz staticdata.Timezone) gomponents.Node {
-						return html.Option(html.Value(tz.TzCode), gomponents.Text(tz.Label))
+						var selected gomponents.Node
+						if tz.TzCode == serverTZ {
+							selected = html.Selected()
+						}
+
+						return html.Option(html.Value(tz.TzCode), gomponents.Text(tz.Label), selected)
 					},
 				),
 			},


### PR DESCRIPTION
Hi there!

Choosing the right timezone each time setting up a new backup is tedious. That's why I think having one selected by default is a good option!

I hesitated to add a specific env config for it, but I ended up using the container's timezone.
I also updated the README accordingly.

In the future, having a searchable select would be even better, but those are a nightmare to do by hand.