### PR TITLE
Feat/timezone bound displays

### DIFF
--- a/internal/view/web/dashboard/backups/list_backups.go
+++ b/internal/view/web/dashboard/backups/list_backups.go
@@ -122,7 +122,7 @@ func listBackups(
 			html.Td(yesNoSpan(backup.OptCreate)),
 			html.Td(yesNoSpan(backup.OptNoComments)),
 			html.Td(component.SpanText(
-				backup.CreatedAt.Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
+				backup.CreatedAt.Local().Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
 			)),
 		))
 	}

--- a/internal/view/web/dashboard/databases/list_databases.go
+++ b/internal/view/web/dashboard/databases/list_databases.go
@@ -105,7 +105,7 @@ func listDatabases(
 				component.SpanText("****************"),
 			),
 			html.Td(component.SpanText(
-				database.CreatedAt.Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
+				database.CreatedAt.Local().Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
 			)),
 		))
 	}

--- a/internal/view/web/dashboard/destinations/list_destinations.go
+++ b/internal/view/web/dashboard/destinations/list_destinations.go
@@ -127,7 +127,7 @@ func listDestinations(
 				component.SpanText("**********"),
 			),
 			html.Td(component.SpanText(
-				destination.CreatedAt.Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
+				destination.CreatedAt.Local().Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
 			)),
 		))
 	}

--- a/internal/view/web/dashboard/executions/list_executions.go
+++ b/internal/view/web/dashboard/executions/list_executions.go
@@ -84,13 +84,13 @@ func listExecutions(
 				execution.BackupIsLocal, execution.DestinationName,
 			)),
 			html.Td(component.SpanText(
-				execution.StartedAt.Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
+				execution.StartedAt.Local().Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
 			)),
 			html.Td(
 				gomponents.If(
 					execution.FinishedAt.Valid,
 					component.SpanText(
-						execution.FinishedAt.Time.Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
+						execution.FinishedAt.Time.Local().Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
 					),
 				),
 			),

--- a/internal/view/web/dashboard/executions/show_execution.go
+++ b/internal/view/web/dashboard/executions/show_execution.go
@@ -78,7 +78,7 @@ func showExecutionButton(
 					html.Tr(
 						html.Th(component.SpanText("Started At")),
 						html.Td(component.SpanText(
-							execution.StartedAt.Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
+							execution.StartedAt.Local().Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
 						)),
 					),
 					gomponents.If(
@@ -86,7 +86,7 @@ func showExecutionButton(
 						html.Tr(
 							html.Th(component.SpanText("Finished At")),
 							html.Td(component.SpanText(
-								execution.FinishedAt.Time.Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
+								execution.FinishedAt.Time.Local().Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
 							)),
 						),
 					),
@@ -104,7 +104,7 @@ func showExecutionButton(
 						html.Tr(
 							html.Th(component.SpanText("Deleted At")),
 							html.Td(component.SpanText(
-								execution.DeletedAt.Time.Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
+								execution.DeletedAt.Time.Local().Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
 							)),
 						),
 					),

--- a/internal/view/web/dashboard/profile/close_all_sessions.go
+++ b/internal/view/web/dashboard/profile/close_all_sessions.go
@@ -43,7 +43,7 @@ func closeAllSessionsForm(sessions []dbgen.Session) gomponents.Node {
 						component.GMap(sessions, func(session dbgen.Session) gomponents.Node {
 							return html.Tr(
 								html.Td(component.SpanText(
-									session.CreatedAt.Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
+									session.CreatedAt.Local().Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
 								)),
 								html.Td(component.SpanText(session.Ip)),
 								html.Td(component.SpanText(session.UserAgent)),

--- a/internal/view/web/dashboard/restorations/list_restorations.go
+++ b/internal/view/web/dashboard/restorations/list_restorations.go
@@ -82,13 +82,13 @@ func listRestorations(
 			}())),
 			html.Td(component.SpanText(restoration.ExecutionID.String())),
 			html.Td(component.SpanText(
-				restoration.StartedAt.Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
+				restoration.StartedAt.Local().Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
 			)),
 			html.Td(
 				gomponents.If(
 					restoration.FinishedAt.Valid,
 					component.SpanText(
-						restoration.FinishedAt.Time.Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
+						restoration.FinishedAt.Time.Local().Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
 					),
 				),
 			),

--- a/internal/view/web/dashboard/restorations/show_restoration.go
+++ b/internal/view/web/dashboard/restorations/show_restoration.go
@@ -54,7 +54,7 @@ func showRestorationButton(
 					html.Tr(
 						html.Th(component.SpanText("Started At")),
 						html.Td(component.SpanText(
-							restoration.StartedAt.Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
+							restoration.StartedAt.Local().Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
 						)),
 					),
 					gomponents.If(
@@ -62,7 +62,7 @@ func showRestorationButton(
 						html.Tr(
 							html.Th(component.SpanText("Finished At")),
 							html.Td(component.SpanText(
-								restoration.FinishedAt.Time.Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
+								restoration.FinishedAt.Time.Local().Format(timeutil.LayoutYYYYMMDDHHMMSSPretty),
 							)),
 						),
 					),


### PR DESCRIPTION
Hi there!

As mentioned in #25, time is always UTC throughout the app. I think it would be better off following the timezone of the container, so I added `.Local()` to every time formatting.

Maybe following the browser's time would be even better, but using SSR makes it more complicated to implement. I think for now it's fine.

Hope you agree!