### PR TITLE
docs: add install on zeabur in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ services:
       retries: 5
 ```
 
+### Install on Zeabur with One Click
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/PISFJX)
+
 ## Configuration
 
 You only need to configure the following environment variables:


### PR DESCRIPTION
[Zeabur](https://zeabur.com) is a platform for deploying services easily. I've made a template to allow users deploy PGBackWeb with just one click
Demo video: https://discord.com/channels/1269791103536599112/1269791103536599115/1273563157150826597