### PR TITLE
Fix S3/Backblaze upload failure by enabling path-style addressing

### DIFF
--- a/internal/integration/storage/s3.go
+++ b/internal/integration/storage/s3.go
@@ -43,7 +43,11 @@ func createS3Client(
 		return nil, fmt.Errorf("error initializing storage config: %w", err)
 	}
 
-	s3Client := s3.NewFromConfig(conf)
+	// Create S3 client with path-style addressing enabled
+	// This is required for S3-compatible services like Backblaze
+	s3Client := s3.NewFromConfig(conf, func(o *s3.Options) {
+		o.UsePathStyle = true
+	})
 	return s3Client, nil
 }
 


### PR DESCRIPTION
- Add UsePathStyle option to S3 client configuration
- Required for S3-compatible services like Backblaze B2
- Restores functionality lost in AWS SDK v1 to v2 migration
- Compatible with Amazon S3, Backblaze, and arm64 architecture

Fixes #140

