### PR TITLE
Add label source to dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.25-trixie AS golang
 FROM debian:trixie
-
+LABEL org.opencontainers.image.source="https://github.com/eduardolat/pgbackweb"
 # Declare ARG to make it available in the RUN commands
 ARG TARGETPLATFORM
 RUN echo "Building for ${TARGETPLATFORM}"


### PR DESCRIPTION
This pull request makes a minor update to the Dockerfile by adding a label that references the GitHub repository source for the image. This helps improve traceability and documentation of the container image. Useful for bot like dependabot or Renovate to fetch the changelog.
source : https://docs.renovatebot.com/key-concepts/changelogs/
https://docs.renovatebot.com/modules/datasource/docker/
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added a source metadata label to the Docker image. This label appears in image metadata on container registries.
  - No changes to build steps, application behavior, or runtime performance.
  - No impact on configuration, deployment steps, or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->