### PR TITLE
Add Renovate configuration for automated dependency management

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,9 +21,9 @@ jobs:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
           LOG_LEVEL: ${{ inputs.DEBUG && 'debug' || 'info' }}
-          RENOVATE_REPOSITORIES: "['${{ github.repository }}']"
+          RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
           RENOVATE_COMMIT_MESSAGE_SUFFIX: '{{#unless groupName}}{{#if (equals updateType "digest")}}(from {{currentDigestShort}}){{else}}(from {{currentVersion}}){{/if}}{{/unless}}'
-          RENOVATE_LABELS: "['dependencies']"
-          RENOVATE_DEPENDENCY_DASHBOARD_LABELS: "['dependencies']"
+          RENOVATE_LABELS: '["dependencies"]'
+          RENOVATE_DEPENDENCY_DASHBOARD_LABELS: '["dependencies"]'
           RENOVATE_EXTENDS: '["config:best-practices","mergeConfidence:all-badges",":pinVersions","security:openssf-scorecard",":prHourlyLimitNone",":separateMultipleMajorReleases",":configMigration"]'
           RENOVATE_PLATFORM: "github"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -2,7 +2,7 @@ name: "Renovate"
 on:
   workflow_dispatch:
     inputs:
-      debug:
+      DEBUG:
         description: "Enable debug logging"
         type: boolean
         required: false
@@ -20,7 +20,7 @@ jobs:
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
-          LOG_LEVEL: ${{ inputs.DEBUG == 'true' && 'debug' || 'info' }}
+          LOG_LEVEL: ${{ inputs.DEBUG && 'debug' || 'info' }}
           RENOVATE_REPOSITORIES: "['${{ github.repository }}']"
           RENOVATE_COMMIT_MESSAGE_SUFFIX: '{{#unless groupName}}{{#if (equals updateType "digest")}}(from {{currentDigestShort}}){{else}}(from {{currentVersion}}){{/if}}{{/unless}}'
           RENOVATE_LABELS: "['dependencies']"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,29 @@
+name: "Renovate"
+on:
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: "Enable debug logging"
+        type: boolean
+        required: false
+        default: false
+  schedule:
+    - cron: "0 0 * * 1" # Triggers the workflow every Monday at midnight
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5.0.0
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v43.0.15
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ inputs.DEBUG == 'true' && 'debug' || 'info' }}
+          RENOVATE_REPOSITORIES: "['${{ github.repository }}']"
+          RENOVATE_COMMIT_MESSAGE_SUFFIX: '{{#unless groupName}}{{#if (equals updateType "digest")}}(from {{currentDigestShort}}){{else}}(from {{currentVersion}}){{/if}}{{/unless}}'
+          RENOVATE_LABELS: "['dependencies']"
+          RENOVATE_DEPENDENCY_DASHBOARD_LABELS: "['dependencies']"
+          RENOVATE_EXTENDS: '["config:best-practices","mergeConfidence:all-badges",":pinVersions","security:openssf-scorecard",":prHourlyLimitNone",":separateMultipleMajorReleases",":configMigration"]'
+          RENOVATE_PLATFORM: "github"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+}


### PR DESCRIPTION
Introduce Renovate configuration files to automate dependency updates and management, enhancing project maintenance and security.

Before merging ensure you have a finegrained token named RENOVATE_TOKEN in your secrets with theses permissions
docs.renovatebot.com/modules/platform/github#permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added an automated dependency-update workflow that runs weekly and can be triggered on demand.
  - Creates consistent dependency-update PRs with standardized labels and commit-message suffixes to simplify triage.
  - Added a Renovate configuration schema to establish update behavior.
  - Reduces manual maintenance effort and improves dependency update cadence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->