### PR TITLE
Add DB_MAX conf

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,10 @@ PBW_PATH_PREFIX=""
 # Your timezone, this impacts logging, backup filenames and default timezone
 # in the web interface.
 TZ=""
+
+# Maximum number of open database connections. Default is 10.
+PBW_DB_MAX_CONNS=""
+
+# Maximum number of idle database connections. Default is 5.
+# Should be <= PBW_DB_MAX_CONNS.
+PBW_DB_MAX_IDLE_CONNS=""

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -13,6 +13,8 @@ type Env struct {
 	PBW_LISTEN_HOST          string `env:"PBW_LISTEN_HOST" envDefault:"0.0.0.0"`
 	PBW_LISTEN_PORT          string `env:"PBW_LISTEN_PORT" envDefault:"8085"`
 	PBW_PATH_PREFIX          string `env:"PBW_PATH_PREFIX" envDefault:""`
+	PBW_DB_MAX_CONNS         int    `env:"PBW_DB_MAX_CONNS" envDefault:"10"`
+	PBW_DB_MAX_IDLE_CONNS    int    `env:"PBW_DB_MAX_IDLE_CONNS" envDefault:"5"`
 }
 
 var (

--- a/internal/database/connect.go
+++ b/internal/database/connect.go
@@ -29,8 +29,14 @@ func Connect(env config.Env) *sql.DB {
 		)
 	}
 
-	db.SetMaxOpenConns(10)
-	logger.Info("connected to DB")
+	// Configure connection pool from environment variables
+	db.SetMaxOpenConns(env.PBW_DB_MAX_CONNS)
+	db.SetMaxIdleConns(env.PBW_DB_MAX_IDLE_CONNS)
+	
+	logger.Info("connected to DB", logger.KV{
+		"maxOpenConns": env.PBW_DB_MAX_CONNS,
+		"maxIdleConns": env.PBW_DB_MAX_IDLE_CONNS,
+	})
 
 	return db
 }


### PR DESCRIPTION
## Summary
Adds environment variables to configure database connection pool limits, providing better control over database resource usage.

## Changes
- Added `PBW_DB_MAX_CONNS` environment variable (default: 10)
- Added `PBW_DB_MAX_IDLE_CONNS` environment variable (default: 5)
- Updated connection pool configuration to use these values
- Added documentation in `.env.example`
- Logs connection pool settings on startup for visibility

## Motivation
- Allows users to limit database connections to prevent connection pool exhaustion
- Useful for environments with connection limits (e.g., managed databases)
- **Workaround for `lib/pq` driver issues**: The current PostgreSQL driver (`lib/pq`) has known prepared statement conflicts in connection pools, especially with managed databases like DigitalOcean. Setting up the exact number of connections allows to avoid using connection pools
- Provides flexibility to tune performance vs. stability based on deployment environment

## Testing
- ✅ All existing tests pass
- ✅ Linting passes  
- ✅ Tested locally with various connection pool configurations
- ✅ Verified single connection mode eliminates prepared statement errors

## Issue
https://github.com/eduardolat/pgbackweb/issues/148