### PR TITLE
Update PostgreSQL data volume path for v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./data:/var/lib/postgresql/data
+      - ./data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s


### PR DESCRIPTION
Postgres 18 creates subfolders under /var/lib/postgresql for each version e.g. 18, 19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker Compose PostgreSQL service configuration to use the correct data storage path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->