### PR TITLE
Add direct backup download action to executions menu

### DIFF
--- a/internal/view/web/dashboard/executions/list_executions.go
+++ b/internal/view/web/dashboard/executions/list_executions.go
@@ -79,6 +79,7 @@ func listExecutions(
 		trs = append(trs, nodx.Tr(
 			nodx.Td(component.OptionsDropdown(
 				showExecutionButton(execution),
+				downloadExecutionDropdownButton(execution),
 				restoreExecutionButton(execution),
 			)),
 			nodx.Td(component.StatusBadge(execution.Status)),

--- a/internal/view/web/dashboard/executions/show_execution.go
+++ b/internal/view/web/dashboard/executions/show_execution.go
@@ -37,6 +37,33 @@ func (h *handlers) downloadExecutionHandler(c echo.Context) error {
 	return c.Redirect(http.StatusFound, link)
 }
 
+func downloadExecutionLink(
+	executionID uuid.UUID, class string, label string,
+) nodx.Node {
+	return nodx.A(
+		nodx.Href(pathutil.BuildPath(fmt.Sprintf("/dashboard/executions/%s/download", executionID))),
+		nodx.Target("_blank"),
+		nodx.Rel("noopener noreferrer"),
+		nodx.Class(class),
+		component.SpanText(label),
+		lucide.Download(),
+	)
+}
+
+func downloadExecutionDropdownButton(
+	execution dbgen.ExecutionsServicePaginateExecutionsRow,
+) nodx.Node {
+	if execution.Status != "success" || !execution.Path.Valid {
+		return nil
+	}
+
+	return downloadExecutionLink(
+		execution.ID,
+		"btn btn-neutral btn-ghost btn-sm w-full flex justify-start",
+		"Download backup",
+	)
+}
+
 func showExecutionButton(
 	execution dbgen.ExecutionsServicePaginateExecutionsRow,
 ) nodx.Node {
@@ -122,13 +149,7 @@ func showExecutionButton(
 					nodx.Div(
 						nodx.Class("flex justify-end items-center space-x-2"),
 						deleteExecutionButton(execution.ID),
-						nodx.A(
-							nodx.Href(pathutil.BuildPath(fmt.Sprintf("/dashboard/executions/%s/download", execution.ID))),
-							nodx.Target("_blank"),
-							nodx.Class("btn btn-primary"),
-							component.SpanText("Download"),
-							lucide.Download(),
-						),
+						downloadExecutionLink(execution.ID, "btn btn-primary", "Download"),
 					),
 				),
 			),

--- a/internal/view/web/dashboard/executions/show_execution_test.go
+++ b/internal/view/web/dashboard/executions/show_execution_test.go
@@ -1,0 +1,49 @@
+package executions
+
+import (
+	"bytes"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/eduardolat/pgbackweb/internal/database/dbgen"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadExecutionDropdownButton(t *testing.T) {
+	executionID := uuid.New()
+
+	t.Run("renders link for successful execution with path", func(t *testing.T) {
+		node := downloadExecutionDropdownButton(dbgen.ExecutionsServicePaginateExecutionsRow{
+			ID:     executionID,
+			Status: "success",
+			Path:   sql.NullString{String: "backup.zip", Valid: true},
+		})
+		require.NotNil(t, node)
+
+		var got bytes.Buffer
+		require.NoError(t, node.Render(&got))
+
+		html := got.String()
+		assert.Contains(t, html, "Download backup")
+		assert.Contains(t, html, "/dashboard/executions/"+executionID.String()+"/download")
+		assert.Contains(t, html, `target="_blank"`)
+		assert.Contains(t, html, `rel="noopener noreferrer"`)
+	})
+
+	t.Run("hides link when execution is not downloadable", func(t *testing.T) {
+		tests := []dbgen.ExecutionsServicePaginateExecutionsRow{
+			{ID: executionID, Status: "running", Path: sql.NullString{String: "backup.zip", Valid: true}},
+			{ID: executionID, Status: "failed", Path: sql.NullString{String: "backup.zip", Valid: true}},
+			{ID: executionID, Status: "success"},
+		}
+
+		for _, test := range tests {
+			t.Run(strings.TrimSpace(test.Status), func(t *testing.T) {
+				assert.Nil(t, downloadExecutionDropdownButton(test))
+			})
+		}
+	})
+}

--- a/internal/view/web/dashboard/executions/show_execution_test.go
+++ b/internal/view/web/dashboard/executions/show_execution_test.go
@@ -3,10 +3,12 @@ package executions
 import (
 	"bytes"
 	"database/sql"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/eduardolat/pgbackweb/internal/database/dbgen"
+	"github.com/eduardolat/pgbackweb/internal/util/pathutil"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,8 +29,12 @@ func TestDownloadExecutionDropdownButton(t *testing.T) {
 		require.NoError(t, node.Render(&got))
 
 		html := got.String()
+		expectedHref := pathutil.BuildPath(
+			fmt.Sprintf("/dashboard/executions/%s/download", executionID),
+		)
+
 		assert.Contains(t, html, "Download backup")
-		assert.Contains(t, html, "/dashboard/executions/"+executionID.String()+"/download")
+		assert.Contains(t, html, expectedHref)
 		assert.Contains(t, html, `target="_blank"`)
 		assert.Contains(t, html, `rel="noopener noreferrer"`)
 	})


### PR DESCRIPTION
## Summary
- add a `Download backup` action to each downloadable execution row menu on `/dashboard/executions`
- reuse the existing `/dashboard/executions/{id}/download` route/handler
- keep the details modal download action intact and add regression coverage for row visibility

Closes #176

## Verification
- `/tmp/go1.26.4/go/bin/gofmt -w internal/view/web/dashboard/executions/list_executions.go internal/view/web/dashboard/executions/show_execution.go internal/view/web/dashboard/executions/show_execution_test.go`
- `PATH=/tmp/go1.26.4/go/bin:$PATH /tmp/go1.26.4/go/bin/go test ./internal/view/web/dashboard/executions ./...`
- `PATH=/tmp/go1.26.4/go/bin:$PATH /tmp/go1.26.4/go/bin/go build -o ./dist/app ./cmd/app/.`
- `PATH=/tmp/go1.26.4/go/bin:$PATH /tmp/go1.26.4/go/bin/go build -o ./dist/change-password ./cmd/changepw/.`
- `npm run prettier -- --check . --ignore-path .prettierignore.tmp` (local `.omx/` and generated `tmp/` excluded)
- `git diff --check`

## Notes
- Docker daemon was not available locally, so verification used a temporary Go toolchain plus project npm dependencies instead of the Docker dev image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a download option to each execution’s action menu, making it easier to access execution output from the list view.
  * Improved the execution detail page so the download link opens in a new tab and is shown only when the execution is available to download.
* **Tests**
  * Added coverage to ensure the download option renders correctly for downloadable executions and is hidden for non-downloadable cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->